### PR TITLE
Fix MDIO communication and make it much faster.

### DIFF
--- a/Core/Inc/miim_library_nano.h
+++ b/Core/Inc/miim_library_nano.h
@@ -8,6 +8,7 @@
 #ifndef INC_MIIM_LIBRARY_NANO_H_
 #define INC_MIIM_LIBRARY_NANO_H_
 
+void MDIO_WAIT(uint16_t tens_of_us);
 void GPIO_SET_MDIO_MODE_INPUT();
 void GPIO_SET_MDIO_MDC_MODE_INPUT();
 void GPIO_SET_MODE_NORMAL();

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -19,6 +19,7 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include "miim_library_nano.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -146,11 +147,26 @@ void Write_Commands_To_IC() {
 		// We are going to assume that for now, the data is sent with the smallest byte [0:7] bits first, then [8:15]
 		Data = ((uint16_t) Commands_Total[Cmd_Index][3] << 8) | (Commands_Total[Cmd_Index][2]);
 
-		for(Generic_Index = 0; Generic_Index <= 10; Generic_Index++) {
-			MIIM_DRIVER_WRITE(PHY, REG, Data);
-			HAL_Delay(1);
-		}
+		MIIM_DRIVER_WRITE(PHY, REG, Data);
+		MDIO_WAIT(1);
 	}
+
+	// Uncomment the following code to verify what was written to the MCU
+	/*
+	for(uint8_t Cmd_Index = 0; Cmd_Index < maximum_commands; Cmd_Index++) {
+		PHY = Commands_Total[Cmd_Index][0];
+		REG = Commands_Total[Cmd_Index][1];
+		if(PHY < 2 || PHY > 24 || REG < 0 || REG > 32) {
+			break;
+		}
+
+		// To verify what was written to the switch chip, add "dynamic printf"-type breakpoint to the following MDIO_WAIT line.
+		// "%u:%02u 0x%02x 0x%02x (%u %u)\n", PHY, REG, Data & 0xFF, (Data >> 8) & 0xFF, Data & 0xFF, (Data >> 8) & 0xFF
+		Data = MIIM_DRIVER_READ(PHY, REG);
+		MDIO_WAIT(1);
+	}
+	// */
+
 }
 
 
@@ -297,26 +313,11 @@ int main(void)
   MX_DMA_Init();
   MX_USART2_UART_Init();
   /* USER CODE BEGIN 2 */
+
   HAL_Delay(1000);
   Configuration_From_Eeprom();
 
   HAL_UART_Receive_DMA(&huart2, Buffer_Rx, buffer_size);
-
-//  Commands_Total[0][0] = 23;
-//  Commands_Total[0][1] = 16;
-//  Commands_Total[0][2] = 20;
-//  Commands_Total[0][3] = 8;
-//  Commands_Total[1][0] = 23;
-//  Commands_Total[1][1] = 17;
-//  Commands_Total[1][2] = 20;
-//  Commands_Total[1][3] = 0;
-//  Commands_Total[2][0] = 23;
-//  Commands_Total[2][1] = 18;
-//  Commands_Total[2][2] = 255;
-//  Commands_Total[2][3] = 255;
-//  Is_Commands_Ready = 1;
-//  Write_Commands_To_IC();
-  //23, 16, 12, 12], [23, 17, 16, 0], [23, 18, 255, 255], [100, 0, 0, 0]]
 
   /* USER CODE END 2 */
 

--- a/Core/Src/miim_library_nano.c
+++ b/Core/Src/miim_library_nano.c
@@ -107,7 +107,7 @@ void _MIIM_DRIVER_START() {
 	// Preamble
 	//HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, GPIO_PIN_SET);
 
-	for (uint8_t i=0; i<5; ++i) {
+	for (uint8_t i=0; i<32; ++i) {
 		_MIIM_DRIVER_CLOCK_PULSE();
 	}
 

--- a/Core/Src/miim_library_nano.c
+++ b/Core/Src/miim_library_nano.c
@@ -8,6 +8,15 @@
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
 
+volatile uint16_t us_timer = 0;
+
+// Allow shorter than 1 ms sleeps; this function takes an argument that represents tens of microseconds.
+// The wait time isn't exact, but it should be around 5-15 us * tens_of_us
+void MDIO_WAIT(uint16_t tens_of_us)
+{
+	// It was measured that one run of this loop takes about 5 us (in Release mode) to 8.5 us (in Debug mode)
+	for (us_timer = 0; us_timer < tens_of_us; ++us_timer) {}
+}
 
 void GPIO_SET_MDIO_MODE_INPUT() {
 	// Set MIDO pin to it's default status with HAL_GPIO_DeInit
@@ -98,14 +107,14 @@ void GPIO_SET_MODE_NORMAL() {
 
 void _MIIM_DRIVER_CLOCK_PULSE() {
 	HAL_GPIO_WritePin(MIIM_MDC_GPIO_Port, MIIM_MDC_Pin, GPIO_PIN_RESET);
-	HAL_Delay(1);
+	MDIO_WAIT(1);
 	HAL_GPIO_WritePin(MIIM_MDC_GPIO_Port, MIIM_MDC_Pin, GPIO_PIN_SET);
-	HAL_Delay(1);
+	MDIO_WAIT(1);
 }
 
 void _MIIM_DRIVER_START() {
 	// Preamble
-	//HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, GPIO_PIN_SET);
+	HAL_GPIO_WritePin(MIIM_MDIO_GPIO_Port, MIIM_MDIO_Pin, GPIO_PIN_SET);
 
 	for (uint8_t i=0; i<32; ++i) {
 		_MIIM_DRIVER_CLOCK_PULSE();
@@ -179,10 +188,11 @@ void _MIIM_DRIVER_WRITE_DATA(uint16_t data) {
 		}
 		_MIIM_DRIVER_CLOCK_PULSE();
 	}
+	// final clock pulse afterwards
+	_MIIM_DRIVER_CLOCK_PULSE();
 	// reset clock and data
 	HAL_GPIO_WritePin(MIIM_MDIO_GPIO_Port, MIIM_MDIO_Pin, GPIO_PIN_RESET);
 	HAL_GPIO_WritePin(MIIM_MDC_GPIO_Port, MIIM_MDC_Pin, GPIO_PIN_RESET);
-	// final clock pulse afterwards?
 }
 
 uint16_t _MIIM_DRIVER_READ_DATA() {
@@ -192,6 +202,8 @@ uint16_t _MIIM_DRIVER_READ_DATA() {
 		data = data + (HAL_GPIO_ReadPin(MIIM_MDIO_GPIO_Port, MIIM_MDIO_Pin) << (15-bitnum));
 		_MIIM_DRIVER_CLOCK_PULSE();
 	}
+	// final clock pulse afterwards
+	_MIIM_DRIVER_CLOCK_PULSE();
 	GPIO_SET_MODE_NORMAL();
 	// Reset clock and data
 	HAL_GPIO_WritePin(MIIM_MDIO_GPIO_Port, MIIM_MDIO_Pin, GPIO_PIN_RESET);


### PR DESCRIPTION
The standard specifies that [preamble is 32 ones](https://en.wikipedia.org/wiki/Management_Data_Input/Output#MDIO_Packet_Format_.28clause_22.29). The MIIM library was only sending 5 ones.

This resulted in some mangled writes and impossible reading of data via MDIO.

For some reason, this was a much bigger problem on Nano than on large Switchblox, but the fix should go to both (I'll test with large switchblox later today).

This has completely fixed our problem with VLAN config on Nano! 🎉